### PR TITLE
feat: Add sban command for silent bans

### DIFF
--- a/routers/moderation.py
+++ b/routers/moderation.py
@@ -22,7 +22,7 @@ class UnbanCallbackData(CallbackData, prefix="unban"):
     chat_id: int
 
 
-@router.message(Command(commands=["ban"]))
+@router.message(Command(commands=["ban", "sban"]))
 async def cmd_ban(message: Message, session: Session, bot: Bot):
     skynet_admin = is_skynet_admin(message)
     admin = await is_admin(message)
@@ -59,8 +59,11 @@ async def cmd_ban(message: Message, session: Session, bot: Bot):
             await message.bot.send_message(chat_id=MTLChats.SpamGroup,
                                          text=f"User (ID: {user_id}) has been banned by "
                                               f"{message.from_user.username} in {message.chat.title} chat.")
-        await cmd_sleep_and_delete(message, 5)
-        await cmd_sleep_and_delete(msg, 5)
+
+        # If the command is sban, delete the messages
+        if message.text.startswith("/sban"):
+            await cmd_sleep_and_delete(message, 5)
+            await cmd_sleep_and_delete(msg, 5)
 
 
 @router.message(Command(commands=["unban"]))


### PR DESCRIPTION
This commit introduces the `sban` command as a "silent" alternative to the existing `ban` command.

- The `ban` and `sban` commands are now handled by the same function.
- When `sban` is used, the bot's confirmation message and the command message are deleted after 5 seconds.
- When `ban` is used, the confirmation message remains in the chat, providing a public record of the action.

This change aligns the bot's functionality with the behavior of similar moderation bots like Combot.