### PR TITLE
fix(stellar): clamp balance cash at zero

### DIFF
--- a/other/img_tools.py
+++ b/other/img_tools.py
@@ -5,6 +5,23 @@ from PIL import Image, ImageDraw, ImageFont
 from other.config_reader import start_path
 
 
+def _load_font(font_path: str, font_size: int):
+    font_candidates = [
+        font_path,
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/System/Library/Fonts/Menlo.ttc",
+        "/System/Library/Fonts/Supplemental/Courier New.ttf",
+    ]
+
+    for candidate in font_candidates:
+        try:
+            return ImageFont.truetype(candidate, font_size)
+        except OSError:
+            continue
+
+    return ImageFont.load_default()
+
+
 def create_image_with_text(
     text,
     font_path="DejaVuSansMono.ttf",
@@ -20,7 +37,7 @@ def create_image_with_text(
     measure_height = canvas_height or 1
     image = Image.new("RGB", (canvas_width, measure_height), color="white")
     draw = ImageDraw.Draw(image)
-    font = ImageFont.truetype(font_path, font_size)
+    font = _load_font(font_path, font_size)
 
     lines = text.splitlines()
     if not lines:

--- a/other/stellar/display_commands.py
+++ b/other/stellar/display_commands.py
@@ -120,7 +120,7 @@ async def get_cash_balance(chat_id: int) -> str:
             assets = await get_balances(treasure["account_id"])
             eurdebt = int(assets.get("EURDEBT", 0))
             eurmtl_amount = int(assets.get("EURMTL", 0))
-            diff = eurdebt - eurmtl_amount
+            diff = max(eurdebt - eurmtl_amount, 0)
             name = treasure["name"] if chat_id == MTLChats.GuarantorGroup else treasure["name"][0]
             s_cash = f"{diff} ".rjust(8)
             s_eurmtl = f"{eurmtl_amount} ".rjust(8)

--- a/tests/other/stellar/test_display_commands.py
+++ b/tests/other/stellar/test_display_commands.py
@@ -1,0 +1,32 @@
+import pytest
+
+from other.constants import MTLChats
+from other.stellar import display_commands
+
+
+@pytest.mark.asyncio
+async def test_get_cash_balance_clamps_negative_cash(monkeypatch):
+    overpaid_account = "G" + "A" * 55
+    positive_account = "G" + "B" * 55
+
+    async def fake_load_table_data(table, sort=None):
+        return [
+            {"account_id": overpaid_account, "enabled": True, "name": "Overpaid"},
+            {"account_id": positive_account, "enabled": True, "name": "Positive"},
+        ]
+
+    async def fake_get_balances(account_id):
+        return {
+            overpaid_account: {"EURDEBT": 50, "EURMTL": 80},
+            positive_account: {"EURDEBT": 100, "EURMTL": 40},
+        }[account_id]
+
+    monkeypatch.setattr(display_commands.grist_manager, "load_table_data", fake_load_table_data)
+    monkeypatch.setattr(display_commands, "get_balances", fake_get_balances)
+
+    result = await display_commands.get_cash_balance(MTLChats.GuarantorGroup)
+
+    assert "|Overpaid|      0 |     80 |" in result
+    assert "|Positive|     60 |     40 |" in result
+    assert "|Итого   |     60 |    120 |" in result
+    assert "-30" not in result

--- a/tests/other/test_img_tools.py
+++ b/tests/other/test_img_tools.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw
 
 from other import img_tools
 
@@ -14,7 +14,7 @@ def test_create_image_with_text_uses_auto_height_when_height_is_none(tmp_path, m
     output_path = tmp_path / "data" / "output_image.png"
     image = Image.open(output_path)
 
-    font = ImageFont.truetype("DejaVuSansMono.ttf", 30)
+    font = img_tools._load_font("DejaVuSansMono.ttf", 30)
     draw = ImageDraw.Draw(Image.new("RGB", (1, 1)))
     expected_text_height = -4
     for line in text.splitlines():


### PR DESCRIPTION
## Summary
- Clamp treasury cash calculation in /balance so the "Наличных" column never goes below zero
- Add a focused test for overpaid treasury rows and totals
- Add font fallback for local balance image generation on macOS/Linux

## Tests
- `POSTGRES_URL=postgresql+asyncpg://user:password@localhost:5432/skynet_db REDIS_URL=redis://localhost:6379/4 .venv/bin/pytest tests/other/stellar/test_display_commands.py tests/other/test_img_tools.py tests/routers/test_stellar.py::test_show_balance_command -q`
- `.venv/bin/ruff check other/stellar/display_commands.py other/img_tools.py tests/other/stellar/test_display_commands.py tests/other/test_img_tools.py`